### PR TITLE
Add robot control interface to grasp library

### DIFF
--- a/grasp_utils/robot_interface/CMakeLists.txt
+++ b/grasp_utils/robot_interface/CMakeLists.txt
@@ -40,7 +40,7 @@ find_package(geometry_msgs REQUIRED)
 find_library(
   ur_modern_driver_LIBRARIES 
   NAMES ur_driver_lib
-  HINTS /usr/local/lib/ur_modern_driver)
+  HINTS /usr/local/lib)
 find_path(ur_modern_driver_INCLUDE_DIRS ur_modern_driver/tcp_socket.h)
 
 # Set include directory path
@@ -48,8 +48,9 @@ include_directories(
   include
   ${rclcpp_INCLUDE_DIRS}
   ${tf2_INCLUDE_DIRS}
-  ${Eigen3_INCLUDE_DIRS}
   ${ur_modern_driver_INCLUDE_DIRS})
+
+include_directories(SYSTEM ${EIGEN3_INCLUDE_DIRS})
 
 # Add robot interface library
 set(${PROJECT_NAME}_LIB_SOURCES

--- a/grasp_utils/robot_interface/CMakeLists.txt
+++ b/grasp_utils/robot_interface/CMakeLists.txt
@@ -1,0 +1,103 @@
+# Copyright (c) 2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required(VERSION 3.5)
+project(robot_interface)
+
+# Default to C99
+if(NOT CMAKE_C_STANDARD)
+  set(CMAKE_C_STANDARD 99)
+endif()
+
+# Default to C++14
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+# find dependencies
+find_package(ament_cmake REQUIRED)
+find_package(tf2 REQUIRED)
+find_package(tf2_eigen REQUIRED)
+find_package(Eigen3 REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(sensor_msgs REQUIRED)
+find_package(geometry_msgs REQUIRED)
+find_library(
+  ur_modern_driver_LIBRARIES 
+  NAMES ur_driver_lib
+  HINTS /usr/local/lib/ur_modern_driver)
+find_path(ur_modern_driver_INCLUDE_DIRS ur_modern_driver/tcp_socket.h)
+
+# Set include directory path
+include_directories(
+  include
+  ${rclcpp_INCLUDE_DIRS}
+  ${tf2_INCLUDE_DIRS}
+  ${Eigen3_INCLUDE_DIRS}
+  ${ur_modern_driver_INCLUDE_DIRS})
+
+# Add robot interface library
+set(${PROJECT_NAME}_LIB_SOURCES
+  src/control_base.cpp
+) 
+add_library(${PROJECT_NAME}_lib ${${PROJECT_NAME}_LIB_SOURCES})
+
+# Add UR robot interface library
+set(UR_LIB_SOURCES
+  src/ur_control.cpp
+)
+add_library(ur_lib ${UR_LIB_SOURCES})
+ament_target_dependencies(ur_lib rclcpp sensor_msgs geometry_msgs)
+target_link_libraries(ur_lib ${PROJECT_NAME}_lib ${ur_modern_driver_LIBRARIES})
+
+# Add test of UR robot interface library
+set(TEST_SOURCE
+  test/ur_test.cpp)
+
+add_executable(ur_test ${TEST_SOURCE})
+ament_target_dependencies(ur_test rclcpp sensor_msgs)
+target_link_libraries(ur_test ur_lib ${PROJECT_NAME}_lib ${ur_modern_driver_LIBRARIES})
+
+# Install library and executables
+install(TARGETS ur_lib ur_test
+  DESTINATION lib/${PROJECT_NAME})
+
+# Install header files  
+install(
+  DIRECTORY include/
+  DESTINATION include
+)
+
+# Install launch files.
+install(DIRECTORY
+  launch
+  DESTINATION share/${PROJECT_NAME}/
+)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  # the following line skips the linter which checks for copyrights
+  # uncomment the line when a copyright and license is not present in all source files
+  #set(ament_cmake_copyright_FOUND TRUE)
+  # the following line skips cpplint (only works in a git repo)
+  # uncomment the line when this package is not in a git repo
+  #set(ament_cmake_cpplint_FOUND TRUE)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_package()

--- a/grasp_utils/robot_interface/README.md
+++ b/grasp_utils/robot_interface/README.md
@@ -13,16 +13,28 @@ mkdir build && cd build
 cmake .. && sudo make install
 ```
 
-Install **robot_interface**:
+Install dependency **ros2_ur_description**:
 
 ```shell
-mkdir -p ~/ws_ros2/src && cd ~/ws_ros2/src
-git clone https://github.com/RoboticsYY/robot_interface.git
+mkdir -p ~/ros2_ws/src && cd ~/ros2_ws/src
+git clone https://github.com/RoboticsYY/ros2_ur_description.git
 cd .. && colcon build
 ```
 
+Install **robot_interface**:
+
+The installation should refer to the installation of **ros2_grasp_library**.
+
 ## Launch
 
+Launch the UR robot control test executable:
+
 ```shell
-ros2 run robot_interface ur_test __params:=`ros2 pkg prefix robot_interface`/share/robot_interface/launch/ur_test.yaml
+ros2 launch robot_interface ur_test.launch.py
+```
+
+Launch the Rivz2 display:
+
+```shell
+ros2 launch ur_description view_ur5_ros2.launch.py
 ```

--- a/grasp_utils/robot_interface/README.md
+++ b/grasp_utils/robot_interface/README.md
@@ -1,0 +1,28 @@
+# robot_interface
+
+ROS2 package to use robot native interface
+
+## Install
+
+Install dependency **ur_modern_driver**:
+
+```shell
+git clone -b libur_modern_driver https://github.com/RoboticsYY/ur_modern_driver.git
+cd libur_modern_driver
+mkdir build && cd build
+cmake .. && sudo make install
+```
+
+Install **robot_interface**:
+
+```shell
+mkdir -p ~/ws_ros2/src && cd ~/ws_ros2/src
+git clone https://github.com/RoboticsYY/robot_interface.git
+cd .. && colcon build
+```
+
+## Launch
+
+```shell
+ros2 run robot_interface ur_test __params:=`ros2 pkg prefix robot_interface`/share/robot_interface/launch/ur_test.yaml
+```

--- a/grasp_utils/robot_interface/include/robot_interface/control_base.hpp
+++ b/grasp_utils/robot_interface/include/robot_interface/control_base.hpp
@@ -1,0 +1,86 @@
+// Copyright (c) 2019 Intel Corporation. All Rights Reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mutex>
+#include <Eigen/Geometry>
+#include <rclcpp/rclcpp.hpp>
+#include <tf2_eigen/tf2_eigen.h>
+#include <sensor_msgs/msg/joint_state.hpp>
+#include <geometry_msgs/msg/pose_stamped.hpp>
+
+struct TcpPose
+{
+  double x, y, z;
+  double alpha, beta, gamma;
+};
+
+class ArmControlBase: public rclcpp::Node
+{
+public:
+
+  ArmControlBase(const std::string node_name, const rclcpp::NodeOptions & options)
+  : Node(node_name, options)
+  {
+    joint_pub_ = this->create_publisher<sensor_msgs::msg::JointState>("/joint_states", 1);
+    time_out_ = 15.0;
+  }
+
+  ~ArmControlBase()
+  {
+  }
+
+  virtual bool moveToTcpPose(double x, double y, double z, 
+                             double alpha, double beta, double gamma, 
+                             double vel, double acc) = 0;
+
+  virtual bool moveToTcpPose(const Eigen::Isometry3d& pose, double vel, double acc);
+
+  virtual bool open(const double distance = 0) = 0;
+
+  virtual bool close(const double distance = 0) = 0;
+
+  virtual bool pick(double x, double y, double z, 
+                    double alpha, double beta, double gamma, 
+                    double vel, double acc, double vel_scale, double approach);
+  
+  virtual bool pick(const geometry_msgs::msg::PoseStamped& pose_stamped, 
+                    double vel, double acc, double vel_scale, double approach);
+
+  virtual bool place(double x, double y, double z, 
+                     double alpha, double beta, double gamma,
+                     double vel, double acc, double vel_scale, double retract);
+
+  virtual bool place(const geometry_msgs::msg::PoseStamped& pose_stamped,
+                     double vel, double acc, double vel_scale, double retract);
+
+  void toTcpPose(const geometry_msgs::msg::PoseStamped& pose_stamped, TcpPose& tcp_pose);
+
+  void toTcpPose(const Eigen::Isometry3d& pose, TcpPose& tcp_pose);
+
+  virtual bool checkTcpGoalArrived(Eigen::Isometry3d& tcp_goal);
+
+protected:
+  // Joint state publisher
+  rclcpp::Publisher<sensor_msgs::msg::JointState>::SharedPtr joint_pub_;
+  // Joint names
+  std::vector<std::string> joint_names_;
+  // Current tcp pose
+  TcpPose tcp_pose_;
+  // Mutex to guard the tcp_pose usage
+  std::mutex m_;
+  // Motion running duration timeout
+  double time_out_;
+};

--- a/grasp_utils/robot_interface/include/robot_interface/ur_control.hpp
+++ b/grasp_utils/robot_interface/include/robot_interface/ur_control.hpp
@@ -129,6 +129,9 @@ public:
   // Function to get tool pose
   bool getTcpPose(RTShared& packet);
 
+  // Parse parameters
+  void parseArgs();
+
 private:
 
   ProgArgs args_;

--- a/grasp_utils/robot_interface/include/robot_interface/ur_control.hpp
+++ b/grasp_utils/robot_interface/include/robot_interface/ur_control.hpp
@@ -1,0 +1,158 @@
+// Copyright (c) 2019 Intel Corporation. All Rights Reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <rclcpp/rclcpp.hpp>
+#include <robot_interface/control_base.hpp>
+
+#include "ur_modern_driver/log.h"
+#include "ur_modern_driver/pipeline.h"
+#include "ur_modern_driver/ur/commander.h"
+#include "ur_modern_driver/ur/factory.h"
+#include "ur_modern_driver/ur/messages.h"
+#include "ur_modern_driver/ur/parser.h"
+#include "ur_modern_driver/ur/producer.h"
+#include "ur_modern_driver/ur/rt_state.h"
+#include "ur_modern_driver/ur/state.h"
+
+static const std::vector<std::string> JOINTS = { "shoulder_pan_joint", "shoulder_lift_joint", "elbow_joint",
+                                                 "wrist_1_joint",      "wrist_2_joint",       "wrist_3_joint" };
+static const std::string HOST = "192.168.0.5";
+static const bool SHUTDOWN_ON_DISCONNECT = true;
+static const int UR_SECONDARY_PORT = 30002;
+static const int UR_RT_PORT = 30003;
+
+struct ProgArgs
+{
+public:
+  std::string host;
+  std::vector<std::string> joint_names;
+  bool shutdown_on_disconnect;
+};
+
+class IgnorePipelineStoppedNotifier : public INotifier
+{
+public:
+  void started(std::string name)
+  {
+    LOG_INFO("Starting pipeline %s", name.c_str());
+  }
+  void stopped(std::string name)
+  {
+    LOG_INFO("Stopping pipeline %s", name.c_str());
+  }
+};
+
+class ShutdownOnPipelineStoppedNotifier : public INotifier
+{
+public:
+  void started(std::string name)
+  {
+    LOG_INFO("Starting pipeline %s", name.c_str());
+  }
+  void stopped(std::string name)
+  {
+    LOG_INFO("Shutting down on stopped pipeline %s", name.c_str());
+    rclcpp::shutdown();
+    exit(1);
+  }
+};
+
+class URControl: public ArmControlBase, public URRTPacketConsumer
+{
+public:
+  URControl(const std::string node_name, const rclcpp::NodeOptions & options = rclcpp::NodeOptions())
+  : ArmControlBase(node_name, options), gripper_powered_up_(false)
+  {
+    for (auto const& joint : JOINTS)
+    {
+      joint_names_.push_back(joint);
+    }
+  }
+
+  ~URControl()
+  {
+    rt_pl_->stop();
+    state_pl_->stop();
+    factory_.reset(nullptr);
+    notifier_ = nullptr;
+    LOG_INFO("UR control interface shut down.");
+  }
+
+  // Overload ArmControlBase functions
+  virtual bool moveToTcpPose(double x, double y, double z, 
+                             double alpha, double beta, double gamma, 
+                             double vel, double acc);
+
+  virtual bool open(const double distance = 0);
+
+  virtual bool close(const double distance = 0);
+
+  // Send URScript to ur robot controller
+  bool urscriptInterface(const std::string command_script);
+
+  // Start socket communication loop
+  bool start();
+
+  // Overload URRTPacketConsumer functions
+  virtual bool consume(RTState_V1_6__7& state);
+  virtual bool consume(RTState_V1_8& state);
+  virtual bool consume(RTState_V3_0__1& state);
+  virtual bool consume(RTState_V3_2__3& state);
+
+  virtual void setupConsumer()
+  {
+  }
+  virtual void teardownConsumer()
+  {
+  }
+  virtual void stopConsumer()
+  {
+  }
+
+  // Functions to publish joint states
+  bool publishJoints(RTShared& packet, rclcpp::Time t);
+  bool publish(RTShared& packet);
+
+  // Function to get tool pose
+  bool getTcpPose(RTShared& packet);
+
+private:
+
+  ProgArgs args_;
+  std::string local_ip_;
+  std::unique_ptr<URFactory> factory_;
+
+  // Robot rt message
+  std::unique_ptr<URParser<RTPacket>> rt_parser_;
+  std::unique_ptr<URStream> rt_stream_;
+  std::unique_ptr<URProducer<RTPacket>> rt_prod_;
+  std::unique_ptr<URCommander> rt_commander_;
+  vector<IConsumer<RTPacket> *> rt_vec_;
+  std::unique_ptr<MultiConsumer<RTPacket>> rt_cons_;
+  std::unique_ptr<Pipeline<RTPacket>> rt_pl_;
+
+  INotifier *notifier_;
+
+  // Robot state message
+  std::unique_ptr<URParser<StatePacket>> state_parser_;
+  std::unique_ptr<URStream> state_stream_;
+  std::unique_ptr<URProducer<StatePacket>> state_prod_;
+  vector<IConsumer<StatePacket> *> state_vec_;
+  std::unique_ptr<MultiConsumer<StatePacket>> state_cons_;
+  std::unique_ptr<Pipeline<StatePacket>> state_pl_;
+
+  bool gripper_powered_up_;
+};

--- a/grasp_utils/robot_interface/launch/ur_test.launch.py
+++ b/grasp_utils/robot_interface/launch/ur_test.launch.py
@@ -1,0 +1,29 @@
+# Copyright (c) 2019 Intel Corporation. All Rights Reserved
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import launch
+import launch.actions
+import launch.substitutions
+import launch_ros.actions
+
+def generate_launch_description():
+    return launch.LaunchDescription([
+        launch.actions.DeclareLaunchArgument(
+            'node_prefix',
+            default_value=[launch.substitutions.EnvironmentVariable('USER'), '_'],
+            description='Prefix for node names'),
+        launch_ros.actions.Node(
+            package='robot_interface', node_executable='ur_test', output='screen',
+            node_name=[launch.substitutions.LaunchConfiguration('node_prefix'), 'ur_test']),
+    ])

--- a/grasp_utils/robot_interface/launch/ur_test.launch.py
+++ b/grasp_utils/robot_interface/launch/ur_test.launch.py
@@ -12,18 +12,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+
 import launch
 import launch.actions
 import launch.substitutions
 import launch_ros.actions
+from ament_index_python.packages import get_package_share_directory
 
 def generate_launch_description():
+
+    # .yaml file for configuring the parameters
+    yaml = os.path.join(
+        get_package_share_directory('robot_interface'), 
+            'launch', 'ur_test.yaml'
+    )
+
     return launch.LaunchDescription([
-        launch.actions.DeclareLaunchArgument(
-            'node_prefix',
-            default_value=[launch.substitutions.EnvironmentVariable('USER'), '_'],
-            description='Prefix for node names'),
+
         launch_ros.actions.Node(
-            package='robot_interface', node_executable='ur_test', output='screen',
-            node_name=[launch.substitutions.LaunchConfiguration('node_prefix'), 'ur_test']),
+            package='robot_interface', node_executable='ur_test', 
+            output='screen', arguments=['__params:='+yaml]),
     ])

--- a/grasp_utils/robot_interface/launch/ur_test.yaml
+++ b/grasp_utils/robot_interface/launch/ur_test.yaml
@@ -1,0 +1,5 @@
+ur_test:
+    ros__parameters:
+        host: "192.168.0.5"
+        shutdown_on_disconnect: true
+        joint_names: ["shoulder_pan_joint", "shoulder_lift_joint", "elbow_joint", "wrist_1_joint", "wrist_2_joint", "wrist_3_joint"]

--- a/grasp_utils/robot_interface/package.xml
+++ b/grasp_utils/robot_interface/package.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>robot_interface</name>
+  <version>0.0.0</version>
+  <description>Native robot motion control interface</description>
+  <maintainer email="yu.yan@intel.com">Yu Yan</maintainer>
+  <license>Apache License 2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <build_depend>rclcpp</build_depend>
+  <build_depend>tf2</build_depend>
+  <build_depend>tf2_eigen</build_depend>
+
+  <exec_depend>rclcpp</exec_depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/grasp_utils/robot_interface/src/control_base.cpp
+++ b/grasp_utils/robot_interface/src/control_base.cpp
@@ -1,0 +1,165 @@
+// Copyright (c) 2019 Intel Corporation. All Rights Reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <robot_interface/control_base.hpp>
+#include <chrono>
+#include <thread>
+
+bool ArmControlBase::moveToTcpPose(const Eigen::Isometry3d& pose, double vel, double acc)
+{
+  TcpPose tcp_pose;
+  toTcpPose(pose, tcp_pose);
+  return this->moveToTcpPose(tcp_pose.x, tcp_pose.y, tcp_pose.z, 
+                             tcp_pose.alpha, tcp_pose.beta, tcp_pose.gamma, vel, acc);
+}
+
+void ArmControlBase::toTcpPose(const geometry_msgs::msg::PoseStamped& pose_stamped, TcpPose& tcp_pose)
+{
+  Eigen::Isometry3d pose_transform;
+  tf2::fromMsg(pose_stamped.pose, pose_transform);
+  toTcpPose(pose_transform, tcp_pose);
+}
+
+void ArmControlBase::toTcpPose(const Eigen::Isometry3d& pose, TcpPose& tcp_pose)
+{
+  tcp_pose.x = pose.translation().x();
+  tcp_pose.y = pose.translation().y();
+  tcp_pose.z = pose.translation().z();
+
+  Eigen::Vector3d euler_angles = pose.rotation().matrix().eulerAngles(0, 1, 2);
+  tcp_pose.alpha = euler_angles[0];
+  tcp_pose.beta = euler_angles[1];
+  tcp_pose.gamma = euler_angles[2]; 
+}
+
+bool ArmControlBase::pick(double x, double y, double z, 
+                          double alpha, double beta, double gamma, 
+                          double vel, double acc, double vel_scale, double approach)
+{
+  Eigen::Isometry3d grasp;
+  grasp = Eigen::AngleAxisd(alpha, Eigen::Vector3d::UnitX())
+           * Eigen::AngleAxisd(beta, Eigen::Vector3d::UnitY())
+           * Eigen::AngleAxisd(gamma, Eigen::Vector3d::UnitZ());
+  grasp = Eigen::Translation3d(x, y, z) * grasp;
+
+  Eigen::Isometry3d pre_grasp;
+  pre_grasp = grasp * Eigen::Translation3d(0, 0, -approach);
+
+  
+  if (// Move to pre_grasp
+      moveToTcpPose(pre_grasp, vel, acc) && checkTcpGoalArrived(pre_grasp) &&
+      // Open gripper
+      open() &&
+      // Move to grasp
+      moveToTcpPose(grasp, vel*vel_scale, acc*vel_scale) && checkTcpGoalArrived(grasp) &&
+      // Close gripper
+      close() &&
+      // Move to pre_grasp
+      moveToTcpPose(pre_grasp, vel*vel_scale, acc*vel_scale) && checkTcpGoalArrived(pre_grasp))
+  {
+    std::cout << "Pick finished." << std::endl;
+    return true;
+  }
+  else
+  {
+    std::cerr << "Pick failed." << std::endl;
+    return false;
+  }
+}
+
+bool ArmControlBase::pick(const geometry_msgs::msg::PoseStamped& pose_stamped, 
+          double vel, double acc, double vel_scale, double approach)
+{
+  TcpPose tcp_pose;
+  toTcpPose(pose_stamped, tcp_pose);
+  return pick(tcp_pose.x, tcp_pose.y, tcp_pose.z, 
+              tcp_pose.alpha, tcp_pose.beta, tcp_pose.gamma, vel, acc, vel_scale, approach);
+}
+
+bool ArmControlBase::place(double x, double y, double z, 
+                           double alpha, double beta, double gamma,
+                           double vel, double acc, double vel_scale, double retract)
+{
+  Eigen::Isometry3d place;
+  place = Eigen::AngleAxisd(alpha, Eigen::Vector3d::UnitX())
+              * Eigen::AngleAxisd(beta, Eigen::Vector3d::UnitY())
+              * Eigen::AngleAxisd(gamma, Eigen::Vector3d::UnitZ()); 
+  place = Eigen::Translation3d(x, y, z) * place;
+
+  Eigen::Isometry3d pre_place;
+  pre_place = place * Eigen::Translation3d(0, 0, -retract);
+
+  
+  if (// Move to pre_place
+      moveToTcpPose(pre_place, vel, acc) && checkTcpGoalArrived(pre_place) &&
+      // Move to place
+      moveToTcpPose(place, vel*vel_scale, acc*vel_scale) && checkTcpGoalArrived(place) &&
+      // Open gripper
+      open() &&
+      // Move to pre_grasp
+      moveToTcpPose(pre_place, vel*vel_scale, acc*vel_scale) && checkTcpGoalArrived(pre_place))
+  {
+    std::cout << "Place finished." << std::endl;
+    return true;
+  }
+  else
+  {
+    std::cerr << "Place failed." << std::endl;
+    return false;
+  }
+}
+
+bool ArmControlBase::place(const geometry_msgs::msg::PoseStamped& pose_stamped, 
+          double vel, double acc, double vel_scale, double retract)
+{
+  TcpPose tcp_pose;
+  toTcpPose(pose_stamped, tcp_pose);
+  return place(tcp_pose.x, tcp_pose.y, tcp_pose.z, 
+               tcp_pose.alpha, tcp_pose.beta, tcp_pose.gamma, vel, acc, vel_scale, retract);
+}
+
+bool ArmControlBase::checkTcpGoalArrived(Eigen::Isometry3d& tcp_goal)
+{
+  bool wait = true;
+  bool arrived = false;
+
+  std::vector<std::vector<double>> record;
+
+  auto start = std::chrono::high_resolution_clock::now();
+  while(wait)
+  {
+    std::unique_lock<std::mutex> lock(m_);
+    Eigen::Vector3d t(tcp_pose_.x, tcp_pose_.y, tcp_pose_.z);
+    if (tcp_goal.translation().isApprox(t, 0.01))
+    {
+      wait = false;
+      arrived = true;
+    }
+    else
+    {
+      auto finish = std::chrono::high_resolution_clock::now();
+      std::chrono::duration<double> elapsed = finish - start;
+      if (elapsed.count() > time_out_)
+      {
+        wait = false;
+        arrived = false;
+        std::cerr << "Motion timeout" << std::endl;
+        printf("Tcp pose: (%f %f %f %f %f %f). \n", tcp_pose_.x, tcp_pose_.y, tcp_pose_.z, 
+                                        tcp_pose_.alpha, tcp_pose_.beta, tcp_pose_.gamma);
+      }
+    }
+  }
+  std::this_thread::sleep_for(std::chrono::milliseconds(500));
+  return arrived;
+}

--- a/grasp_utils/robot_interface/src/ur_control.cpp
+++ b/grasp_utils/robot_interface/src/ur_control.cpp
@@ -68,7 +68,7 @@ bool URControl::urscriptInterface(const std::string command_script)
   return res;
 }
 
-bool URControl::start()
+void URControl::parseArgs()
 {
   // Initialize parameter client
   auto parameters_client = std::make_shared<rclcpp::SyncParametersClient>(this);
@@ -94,7 +94,10 @@ bool URControl::start()
   }
   RCLCPP_INFO(this->get_logger(), ss.str().c_str());
   RCLCPP_INFO(this->get_logger(), std::to_string(args_.shutdown_on_disconnect));
+}
 
+bool URControl::start()
+{
   // Initialize socket communication
   factory_.reset(new URFactory(args_.host));
 

--- a/grasp_utils/robot_interface/src/ur_control.cpp
+++ b/grasp_utils/robot_interface/src/ur_control.cpp
@@ -1,0 +1,187 @@
+// Copyright (c) 2019 Intel Corporation. All Rights Reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <robot_interface/ur_control.hpp>
+
+bool URControl::moveToTcpPose(double x, double y, double z, 
+                              double alpha, double beta, double gamma, 
+                              double vel, double acc)
+{
+  std::string command_script = "movej(p[" + 
+                               std::to_string(x) + "," + std::to_string(y) + "," + std::to_string(z) + "," +
+                               std::to_string(alpha) + "," + std::to_string(beta) + "," + std::to_string(gamma) + "]," + 
+                               std::to_string(vel) + "," + std::to_string(acc) + ")\n";
+  urscriptInterface(command_script);
+  return true;
+}
+
+bool URControl::open(const double distance)
+{
+  rt_commander_->setToolVoltage(static_cast<uint8_t>(24));
+  if (!gripper_powered_up_)
+  {
+    rt_commander_->setToolVoltage(static_cast<uint8_t>(24));
+    gripper_powered_up_ = true;
+    std::cout << "Gripper powered up." << std::endl;    
+  }
+
+  rt_commander_->setDigitalOut(16, true);
+  rt_commander_->setDigitalOut(17, false);
+  std::this_thread::sleep_for(std::chrono::seconds(1));
+  return true;
+}
+
+bool URControl::close(const double distance)
+{
+  if (!gripper_powered_up_)
+  {
+    rt_commander_->setToolVoltage(static_cast<uint8_t>(24));
+    gripper_powered_up_ = true;
+    std::cout << "Gripper powered up." << std::endl;
+  }
+
+  rt_commander_->setDigitalOut(16, false);
+  rt_commander_->setDigitalOut(17, true);
+  std::this_thread::sleep_for(std::chrono::seconds(1));
+  return true;
+}
+
+bool URControl::urscriptInterface(const std::string command_script)
+{
+  bool res = rt_commander_->uploadProg(command_script);
+  if (!res)
+  {
+    LOG_ERROR("Program upload failed!");
+  }
+
+  return res;
+}
+
+bool URControl::start()
+{
+  // Initialize parameter client
+  auto parameters_client = std::make_shared<rclcpp::SyncParametersClient>(this);
+  while (!parameters_client->wait_for_service(1s)) {
+    if (!rclcpp::ok()) {
+      RCLCPP_ERROR(this->get_logger(), "Interrupted while waiting for the service. Exiting.");
+      rclcpp::shutdown();
+    }
+    RCLCPP_INFO(this->get_logger(), "service not available, waiting again...");
+  }
+
+  // Get parameters
+  args_.host = parameters_client->get_parameter("host", HOST);
+  args_.joint_names = parameters_client->get_parameter("joint_names", JOINTS);
+  args_.shutdown_on_disconnect = parameters_client->get_parameter("shutdown_on_disconnect", SHUTDOWN_ON_DISCONNECT);
+
+  // Print parameters
+  RCLCPP_INFO(this->get_logger(), args_.host);
+  std::stringstream ss;
+  for (auto & name : args_.joint_names)
+  {
+    ss << name << " ";
+  }
+  RCLCPP_INFO(this->get_logger(), ss.str().c_str());
+  RCLCPP_INFO(this->get_logger(), std::to_string(args_.shutdown_on_disconnect));
+
+  // Initialize socket communication
+  factory_.reset(new URFactory(args_.host));
+
+  notifier_ = nullptr;
+
+  if (args_.shutdown_on_disconnect)
+  {
+    LOG_INFO("Notifier: Pipeline disconnect will shutdown the node");
+    notifier_ = new ShutdownOnPipelineStoppedNotifier();
+  }
+  else
+  {
+    LOG_INFO("Notifier: Pipeline disconnect will be ignored.");
+    notifier_ = new IgnorePipelineStoppedNotifier();
+  }
+
+  // RT packets
+  rt_parser_ = factory_->getRTParser();
+  rt_stream_.reset(new URStream(args_.host, UR_RT_PORT));
+  rt_prod_.reset(new URProducer<RTPacket>(*rt_stream_, *rt_parser_));
+  rt_commander_ = factory_->getCommander(*rt_stream_);
+  rt_vec_.push_back(this);
+  rt_cons_.reset(new MultiConsumer<RTPacket>(rt_vec_));
+  rt_pl_.reset(new Pipeline<RTPacket>(*rt_prod_, *rt_cons_, "RTPacket", *notifier_));
+
+  // Message packets
+  state_parser_ = factory_->getStateParser();
+  state_stream_.reset(new URStream(args_.host, UR_SECONDARY_PORT));
+  state_prod_.reset(new URProducer<StatePacket>(*state_stream_, *state_parser_));
+  state_cons_.reset(new MultiConsumer<StatePacket>(state_vec_));
+  state_pl_.reset(new Pipeline<StatePacket>(*state_prod_, *state_cons_, "StatePacket", *notifier_));
+
+  LOG_INFO("Starting main loop");
+
+  rt_pl_->run();
+  state_pl_->run();
+
+  return true;
+}
+
+bool URControl::getTcpPose(RTShared& packet)
+{
+  auto tv = packet.tool_vector_actual;
+  
+  tcp_pose_.x = tv.position.x;
+  tcp_pose_.y = tv.position.y;
+  tcp_pose_.z = tv.position.z;
+  tcp_pose_.alpha = tv.rotation.x;
+  tcp_pose_.beta = tv.rotation.y;
+  tcp_pose_.gamma = tv.rotation.z;
+
+  return true;
+}
+
+bool URControl::consume(RTState_V1_6__7& state)
+{
+  return publish(state) && getTcpPose(state);
+}
+bool URControl::consume(RTState_V1_8& state)
+{
+  return publish(state) && getTcpPose(state);
+}
+bool URControl::consume(RTState_V3_0__1& state)
+{
+  return publish(state) && getTcpPose(state);
+}
+bool URControl::consume(RTState_V3_2__3& state)
+{
+  return publish(state) && getTcpPose(state);
+}
+
+bool URControl::publish(RTShared& packet)
+{
+  return publishJoints(packet, rclcpp::Node::now());
+}
+
+bool URControl::publishJoints(RTShared& packet, rclcpp::Time t)
+{
+  sensor_msgs::msg::JointState joint_msg;
+  joint_msg.header.stamp = t;
+
+  joint_msg.name.assign(joint_names_.begin(), joint_names_.end());
+  joint_msg.position.assign(packet.q_actual.begin(), packet.q_actual.end());
+  joint_msg.velocity.assign(packet.qd_actual.begin(), packet.qd_actual.end());
+  joint_msg.effort.assign(packet.i_actual.begin(), packet.i_actual.end());
+
+  joint_pub_->publish(joint_msg);
+
+  return true;
+}

--- a/grasp_utils/robot_interface/test/ur_test.cpp
+++ b/grasp_utils/robot_interface/test/ur_test.cpp
@@ -22,6 +22,7 @@ int main(int argc, char * argv[])
                                                         .allow_undeclared_parameters(true)
                                                         .automatically_declare_parameters_from_overrides(true));
 
+  node->parseArgs();
   node->start();
 
   rclcpp::sleep_for(std::chrono::seconds(2));

--- a/grasp_utils/robot_interface/test/ur_test.cpp
+++ b/grasp_utils/robot_interface/test/ur_test.cpp
@@ -1,0 +1,39 @@
+// Copyright (c) 2019 Intel Corporation. All Rights Reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <robot_interface/ur_control.hpp>
+
+int main(int argc, char * argv[])
+{
+  rclcpp::init(argc, argv);
+
+  auto node = std::make_shared<URControl>("ur_test",  rclcpp::NodeOptions()
+                                                        .allow_undeclared_parameters(true)
+                                                        .automatically_declare_parameters_from_overrides(true));
+
+  node->start();
+
+  rclcpp::sleep_for(std::chrono::seconds(2));
+
+  node->moveToTcpPose(-0.350, -0.296, 0.12, 3.14159, 0, 0, 0.3, 0.3);
+
+  while(rclcpp::ok())
+  {
+    node->pick(-0.153, -0.433, 0.145, 2.8, -0.144, 0.0245, 1.05, 1.4, 0.5, 0.1);
+
+    node->place(-0.350, -0.296, 0.145, 3.14159, 0, 0, 1.05, 1.4, 0.5, 0.1);
+  }
+  rclcpp::shutdown();
+  return 0;
+}


### PR DESCRIPTION
This PR intends to add a native robot control interface to ros2_grasp_library.

The files added to `ros2_grasp_library/grasp_utils/robot_interface`:
```
├── CMakeLists.txt
├── include
│   └── robot_interface
│       ├── control_base.hpp        # General robot control interface
│       └── ur_control.hpp          # UR robot control interface
├── launch
│   ├── ur_test.launch.py
│   └── ur_test.yaml
├── package.xml
├── README.md
├── src
│   ├── control_base.cpp
│   └── ur_control.cpp
└── test
    └── ur_test.cpp                 # Test to UR robot control interface
```

More documents will be added later.