### PR TITLE
Change default frame name to avoid frame jump

### DIFF
--- a/grasp_utils/handeye_dashboard/README.md
+++ b/grasp_utils/handeye_dashboard/README.md
@@ -97,7 +97,7 @@ The result can be published without launching the whole GUI on command line:
 #ros2 run tf2_ros static_transform_publisher <Translation x, y, z> <Rotation x, y, z, w> <from_frame> <to_frame>
 # NOTE the quaternion stored in "camera_robot.txt" is <w, x, y, z>
 
-ros2 run tf2_ros static_transform_publisher -0.032727495589941216, -0.09304065368400717, 0.0003508296697299189 0.01090594636560865, -0.009141740972837598, -0.0174086912647742, 0.9997471812284859 base camera_color_optical_frame
+ros2 run tf2_ros static_transform_publisher -0.032727495589941216, -0.09304065368400717, 0.0003508296697299189 0.01090594636560865, -0.009141740972837598, -0.0174086912647742, 0.9997471812284859 base camera_link
 ```
 
 ## 4.Result

--- a/grasp_utils/handeye_dashboard/src/handeye_dashboard/handeye_calibration.py
+++ b/grasp_utils/handeye_dashboard/src/handeye_dashboard/handeye_calibration.py
@@ -112,7 +112,7 @@ class HandEyeCalibration(Plugin):
     self.l1.setFixedWidth(150)
     self.l1.setAlignment(QtCore.Qt.AlignRight | QtCore.Qt.AlignVCenter)
     self.camera_frame = QLineEdit(self.widget)
-    self.camera_frame.setText("camera_color_optical_frame")
+    self.camera_frame.setText("camera_link")
     self.toolbar1 = QToolBar()
     self.toolbar1.addWidget(self.l1)
     self.toolbar1.addWidget(self.camera_frame)


### PR DESCRIPTION
Since the new realsense node will publish transform `camera_link -> camera_color_optical_frame`, if user publishes a new transform `base -> camera_color_optical_frame`, the frames will conflicts and jumps between each other. This is known to be a ROS2 issue. This PR intends to provide a temporal work around that avoid publishing conflict transforms. 