### PR TITLE
Add calibration parameter client and generate grasp approach vectors from x, y axes

### DIFF
--- a/grasp_utils/robot_interface/CMakeLists.txt
+++ b/grasp_utils/robot_interface/CMakeLists.txt
@@ -69,7 +69,7 @@ set(${PROJECT_NAME}_SOURCES
   src/control_base.cpp
   src/control_ur.cpp
 ) 
-add_library(${PROJECT_NAME} ${${PROJECT_NAME}_SOURCES})
+add_library(${PROJECT_NAME} SHARED ${${PROJECT_NAME}_SOURCES})
 ament_target_dependencies(${PROJECT_NAME} rclcpp sensor_msgs geometry_msgs tf2_ros)
 target_link_libraries(${PROJECT_NAME} ${ur_modern_driver_LIBRARIES})
 

--- a/grasp_utils/robot_interface/include/robot_interface/control_base.hpp
+++ b/grasp_utils/robot_interface/include/robot_interface/control_base.hpp
@@ -300,12 +300,13 @@ public:
   void updateTFGoal(const geometry_msgs::msg::PoseStamped& pose_stamped);
 
   /**
-   * @brief This function is used to rotate a unit vector along z axis, i.e. (0, 0, 1) by the assigned rpy euler angles.
+   * @brief This function is used to rotate the three coordinate system axes by the assigned rpy euler angles.
    * @param alpha Rotation euler angle around X axis.
    * @param beta Rotation euler angle around Y axis.
    * @param gamma Rotation euler angle around Z axis.
+   * @return The rotated axes, dimension 3.
    */
-  Eigen::Vector3d getUnitApproachVector(const double& alpha, const double& beta, const double& gamma);
+  std::vector<Eigen::Vector3d> getUnitApproachVectors(const double& alpha, const double& beta, const double& gamma);
 
 protected:
   /// Joint state publisher


### PR DESCRIPTION
This PR intends to add two functions to the project:

1. Add a parameter client to the calibration dashboard in order to signal calibration finish state.
2. Generate grasp approaching vectors from x, y axes, so that in future it is easy to add pick/place in the directions along x, y axes not only z axes.